### PR TITLE
Skip empty actions when looking for parameterDefinitions

### DIFF
--- a/jenkins_api.py
+++ b/jenkins_api.py
@@ -193,6 +193,8 @@ class ApiJob(object):
         actions = self.dct.get('actions') or []
         self._path = "/job/" + self.name
         for action in actions:
+            if action is None:
+                continue
             if action.get('parameterDefinitions'):
                 self._build_trigger_path = self._path + "/buildWithParameters"
                 break


### PR DESCRIPTION
When jobs are generated using jenkins-job-builder some jobs sometimes get empty element in `actions` array in the job:

```
actions: [{
    'parameterDefinitions': [{...}]
},
{
}
]
```

This fixes that issue.